### PR TITLE
Implemented a minutes flag for the reset command

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(
     author = "Guy Edwards <guyfedwards@gmail.com>",
-    version = "1.1",
+    version = "1.2",
     about = "Simple pomodoro timer"
 )]
 pub struct App {
@@ -33,7 +33,11 @@ pub enum Command {
     },
 
     /// Reset timer to 20 mins
-    Reset,
+    Reset {
+        /// Reset the timer to a specified amount of minutes
+       #[arg(short, long = "min")]
+        minutes: Option<i64>,
+    },
 }
 
 impl std::fmt::Display for Command {


### PR DESCRIPTION
Resolves #1 

This pr adds a `--min` flag for the `reset` command that lets a user specify a time in minutes which the clock gets reset to.